### PR TITLE
infinite mass collision resolution

### DIFF
--- a/src/physics/collider.h
+++ b/src/physics/collider.h
@@ -10,18 +10,9 @@ namespace ramiel {
 
 
     struct Collider : public Dynamics {
-        bool responsive;
-        float mass;
-
         Collider(
-            Dynamics dynamics = Dynamics(),
-            bool responsive = true,
-            float mass = 1.0f
-        ) :
-            Dynamics(dynamics),
-            responsive(responsive),
-            mass(mass)
-        {}
+            Dynamics dynamics = Dynamics()
+        ) : Dynamics(dynamics) {}
 
         virtual ColliderType getType() const = 0;
         virtual ~Collider() {}
@@ -29,16 +20,17 @@ namespace ramiel {
 
 
     struct SphereCollider : public Collider {
+        float mass;
         float hbxrad;
 
         SphereCollider(
             float hbxrad,
             Dynamics dynamics = Dynamics(),
-            bool responsive = true,
-            float mass = 1.0f
+            float mass = 0.0f
         ) : 
-            Collider(dynamics, responsive, mass),
-            hbxrad(hbxrad)
+            hbxrad(hbxrad),
+            Collider(dynamics),
+            mass(mass)
         {}
 
         virtual ColliderType getType() const {
@@ -48,16 +40,17 @@ namespace ramiel {
 
 
     struct AabbCollider : public Collider {
+        float mass;
         Vec3f size;
 
         AabbCollider(
             Vec3f size,
             Dynamics dynamics = Dynamics(),
-            bool responsive = true,
-            float mass = 1.0f
+            float mass = 0.0f
         ) : 
-            Collider(dynamics, responsive, mass),
-            size(size)
+            size(size),
+            Collider(dynamics),
+            mass(mass)
         {}
 
         virtual ColliderType getType() const {

--- a/src/physics/collider.h
+++ b/src/physics/collider.h
@@ -65,42 +65,4 @@ namespace ramiel {
         };
     };
 
-
-    struct ObbCollider : public Collider {
-        Vec3f size;
-
-        ObbCollider(
-            Vec3f size,
-            Dynamics dynamics = Dynamics(),
-            bool responsive = true,
-            float mass = 1.0f
-        ) : 
-            Collider(dynamics, responsive, mass),
-            size(size)
-        {}
-
-        virtual ColliderType getType() const {
-            return ColliderType(typeid(ObbCollider));
-        };
-    };
-
-
-    struct MeshCollider : public Collider {
-        Mesh<MeshVertex>& mesh;
-
-        MeshCollider(
-            Mesh<MeshVertex>& mesh,
-            Dynamics dynamics = Dynamics(),
-            bool responsive = true,
-            float mass = 1.0f
-        ) : 
-            Collider(dynamics, responsive, mass),
-            mesh(mesh)
-        {}
-
-        virtual ColliderType getType() const {
-            return ColliderType(typeid(MeshCollider));
-        };
-    };
-
 }

--- a/src/physics/collisionhandle.cpp
+++ b/src/physics/collisionhandle.cpp
@@ -4,61 +4,80 @@
 namespace ramiel {
 
     Collide_Sph_Sph::Collide_Sph_Sph(Collider* sphere1, Collider* sphere2)
-        : sphere1(*static_cast<SphereCollider*>(sphere1))
-        , sphere2(*static_cast<SphereCollider*>(sphere2))
+        : sphere1(static_cast<SphereCollider*>(sphere1))
+        , sphere2(static_cast<SphereCollider*>(sphere2))
         , time(0.0f)
     {}
 
 
     bool Collide_Sph_Sph::detect() {
-        Vec3f pos_r = sphere2.pos - sphere1.pos;
+        Vec3f pos_r = sphere2->pos - sphere1->pos;
         float dist = dot(pos_r, pos_r); // dist^2
-        float r = sphere1.hbxrad + sphere2.hbxrad;
+        float r = sphere1->hbxrad + sphere2->hbxrad;
         if (dist > r * r) return false;
 
         float depth = r - std::sqrt(dist);
-        time = depth / mag(sphere2.posVel - sphere1.posVel);
+        time = depth / mag(sphere2->posVel - sphere1->posVel);
 
         return true;
     }
 
     
     void Collide_Sph_Sph::resolve() {
-        sphere1.pos -= sphere1.posVel * time;
-        sphere2.pos -= sphere2.posVel * time;
-        Vec3f n = normalize(sphere2.pos - sphere1.pos);
+        if (!sphere1->mass && !sphere2->mass) return;
+        if (!sphere1->mass) {
+            resolveIC();
+            return;
+        }
+        if (!sphere2->mass) {
+            std::swap(sphere1, sphere2);
+            resolveIC();
+            return;
+        }
 
-        const float m = 2.0f / (sphere1.mass + sphere2.mass);
-        Vec3f v1_p = sphere1.posVel - n * sphere2.mass * m * dot(sphere1.posVel - sphere2.posVel, n);
-        Vec3f v2_p = sphere2.posVel - n * sphere1.mass * m * dot(sphere2.posVel - sphere1.posVel, n);
-        sphere1.posVel = v1_p;
-        sphere2.posVel = v2_p;
+        sphere1->pos -= sphere1->posVel * time;
+        sphere2->pos -= sphere2->posVel * time;
+        Vec3f n = normalize(sphere2->pos - sphere1->pos);
 
-        sphere1.pos += sphere1.posVel * time;
-        sphere2.pos += sphere2.posVel * time;
+        const float m = 2.0f / (sphere1->mass + sphere2->mass);
+        Vec3f v1_p = sphere1->posVel - n * sphere2->mass * m * dot(sphere1->posVel - sphere2->posVel, n);
+        Vec3f v2_p = sphere2->posVel - n * sphere1->mass * m * dot(sphere2->posVel - sphere1->posVel, n);
+        sphere1->posVel = v1_p;
+        sphere2->posVel = v2_p;
+
+        sphere1->pos += sphere1->posVel * time;
+        sphere2->pos += sphere2->posVel * time;
+    }
+
+
+    void Collide_Sph_Sph::resolveIC() {
+        sphere2->pos -= sphere2->posVel * time;
+        Vec3f n = normalize(sphere2->pos - sphere1->pos);
+        sphere2->posVel -= n * 2.0f * dot(sphere2->posVel, n);
+        sphere2->pos += sphere2->posVel * time;
     }
 
 
     Collide_Aabb_Aabb::Collide_Aabb_Aabb(Collider* box1, Collider* box2)
-        : box1(*static_cast<AabbCollider*>(box1))
-        , box2(*static_cast<AabbCollider*>(box2))
+        : box1(static_cast<AabbCollider*>(box1))
+        , box2(static_cast<AabbCollider*>(box2))
         , time(std::numeric_limits<float>::max())
         , axis(0)
     {}
 
     
     bool Collide_Aabb_Aabb::detect() {
-        Vec3f box1_min = box1.pos - box1.size;
-        Vec3f box1_max = box1.pos + box1.size;
-        Vec3f box2_min = box2.pos - box2.size;
-        Vec3f box2_max = box2.pos + box2.size;
+        Vec3f box1_min = box1->pos - box1->size;
+        Vec3f box1_max = box1->pos + box1->size;
+        Vec3f box2_min = box2->pos - box2->size;
+        Vec3f box2_max = box2->pos + box2->size;
 
         if (box1_min[X] > box2_max[X] || box2_min[X] > box1_max[X]) return false;
         if (box1_min[Y] > box2_max[Y] || box2_min[Y] > box1_max[Y]) return false;
         if (box1_min[Z] > box2_max[Z] || box2_min[Z] > box1_max[Z]) return false;
 
         for (size_t i = 0; i < 3; ++i) {
-            float vel_r = box2.posVel[i] - box1.posVel[i];
+            float vel_r = box2->posVel[i] - box1->posVel[i];
             if (!vel_r) continue;
             float depth = vel_r < 0.0f ? box1_max[i] - box2_min[i] : box2_max[i] - box1_min[i];
             float t = std::abs(depth / vel_r);
@@ -73,17 +92,34 @@ namespace ramiel {
 
     
     void Collide_Aabb_Aabb::resolve() {
-        box1.pos[axis] -= box1.posVel[axis] * time;
-        box2.pos[axis] -= box2.posVel[axis] * time;
-        
-        float m = 1.0f / (box1.mass + box2.mass);
-        float v1_p = (box1.mass - box2.mass) * m * box1.posVel[axis] + 2.0f * box2.mass * m * box2.posVel[axis];
-        float v2_p = (box2.mass - box1.mass) * m * box2.posVel[axis] + 2.0f * box1.mass * m * box1.posVel[axis];
-        box1.posVel[axis] = v1_p;
-        box2.posVel[axis] = v2_p;
+        if (!box1->mass && !box2->mass) return;
+        if (!box1->mass) {
+            resolveIC();
+            return;
+        }
+        if (!box2->mass) {
+            std::swap(box1, box2);
+            resolveIC();
+            return;
+        }
 
-        box1.pos[axis] += box1.posVel[axis] * time;
-        box2.pos[axis] += box2.posVel[axis] * time;
+        box1->pos[axis] -= box1->posVel[axis] * time;
+        box2->pos[axis] -= box2->posVel[axis] * time;
+        
+        float m = 1.0f / (box1->mass + box2->mass);
+        float v1_p = (box1->mass - box2->mass) * m * box1->posVel[axis] + 2.0f * box2->mass * m * box2->posVel[axis];
+        float v2_p = (box2->mass - box1->mass) * m * box2->posVel[axis] + 2.0f * box1->mass * m * box1->posVel[axis];
+        box1->posVel[axis] = v1_p;
+        box2->posVel[axis] = v2_p;
+
+        box1->pos[axis] += box1->posVel[axis] * time;
+        box2->pos[axis] += box2->posVel[axis] * time;
+    }
+
+
+    void Collide_Aabb_Aabb::resolveIC() {
+        box2->pos[axis] -= 2.0f * box2->posVel[axis] * time;
+        box2->posVel[axis] *= -1.0f;
     }
 
 }

--- a/src/physics/collisionhandle.h
+++ b/src/physics/collisionhandle.h
@@ -11,9 +11,11 @@ namespace ramiel {
     };
 
 
-    struct Collide_Sph_Sph : public CollisionHandler {
-        SphereCollider& sphere1;
-        SphereCollider& sphere2;
+    class Collide_Sph_Sph : public CollisionHandler {
+        void resolveIC();
+    public:
+        SphereCollider* sphere1;
+        SphereCollider* sphere2;
         float time;
         Collide_Sph_Sph(Collider* sphere1, Collider* sphere2);
         virtual bool detect() override;
@@ -21,9 +23,11 @@ namespace ramiel {
     };
 
 
-    struct Collide_Aabb_Aabb : public CollisionHandler {
-        AabbCollider& box1;
-        AabbCollider& box2;
+    class Collide_Aabb_Aabb : public CollisionHandler {
+        void resolveIC();
+    public:
+        AabbCollider* box1;
+        AabbCollider* box2;
         float time;
         size_t axis;
         Collide_Aabb_Aabb(Collider* box1, Collider* box2);

--- a/tests/physics/collisionhandle.test.cpp
+++ b/tests/physics/collisionhandle.test.cpp
@@ -5,8 +5,8 @@ using namespace ramiel;
 
 
 TEST_CASE("sphere-sphere", "[collision][sphere]") {
-    SphereCollider o1(0.5f, Dynamics(Vec3f(), Vec3f(), { -3.3f,  6.9f, 2.7f }), true, 1.8f);
-    SphereCollider o2(0.85, Dynamics({ 0.25f, 1.0f, 0.52f }, Vec3f(), { -2.8f, -3.3f, 7.9f }), true, 2.5f);
+    SphereCollider o1(0.5f, Dynamics(Vec3f(), Vec3f(), { -3.3f,  6.9f, 2.7f }), 1.8f);
+    SphereCollider o2(0.85, Dynamics({ 0.25f, 1.0f, 0.52f }, Vec3f(), { -2.8f, -3.3f, 7.9f }), 2.5f);
 
     Vec3f o1_pos_expected = { -0.02837f, -0.13793f, -0.05067f };
     Vec3f o2_pos_expected = {  0.27042f,  1.09931f,  0.55648f };
@@ -33,8 +33,8 @@ TEST_CASE("sphere-sphere", "[collision][sphere]") {
 
 
 TEST_CASE("aabb-aabb", "[collision][aabb]") {
-    AabbCollider o1({ 1.0f, 0.8f, 1.1f }, Dynamics({ -1.1f, -0.3f, -0.6f }, Vec3f(), {  9.1f, -6.5f, -8.4f }), true, 0.9f);
-    AabbCollider o2({ 1.1f, 1.4f, 0.6f }, Dynamics({ -1.5f,  0.5f, -1.0f }, Vec3f(), { -8.6f,  2.6f, -8.1f }), true, 1.0f);
+    AabbCollider o1({ 1.0f, 0.8f, 1.1f }, Dynamics({ -1.1f, -0.3f, -0.6f }, Vec3f(), {  9.1f, -6.5f, -8.4f }), 0.9f);
+    AabbCollider o2({ 1.1f, 1.4f, 0.6f }, Dynamics({ -1.5f,  0.5f, -1.0f }, Vec3f(), { -8.6f,  2.6f, -8.1f }), 1.0f);
 
     Vec3f o1_pos_expected = { -3.73158f, -0.3f, -0.6f };
     Vec3f o2_pos_expected = {  0.86842f,  0.5f, -1.0f };


### PR DESCRIPTION
re-added infinite mass collision resolution. moved mass from collider base to derived, which will allow for colliders without mass in the future, such as lines and planes.