### PR TITLE
Vertex tuple

### DIFF
--- a/include/ramiel/data.h
+++ b/include/ramiel/data.h
@@ -2,4 +2,5 @@
 
 #include "../src/data/mesh.h"
 #include "../src/data/texture.h"
+#include "../src/data/tuple.h"
 #include "../src/data/voidbuffer.h"

--- a/src/data/tuple.h
+++ b/src/data/tuple.h
@@ -18,7 +18,7 @@ namespace ramiel {
     };
 
     template<typename T, typename... Ts>
-    struct ReverseTs : private ReverseTs<Ts...> {
+    struct ReverseTs {
         using Type = decltype(cat(
             typename ReverseTs<Ts...>::Type{},
             ReverseTs<T>{}
@@ -155,7 +155,6 @@ namespace ramiel {
     // read more about it here:
     // blog: https://alexpolt.github.io/type-loophole.html
     // github: https://github.com/alexpolt/luple/
-
 
     template<class T, int N>
     struct FieldIndex {

--- a/src/data/tuple.h
+++ b/src/data/tuple.h
@@ -1,0 +1,199 @@
+#include <type_traits>
+#include <utility>
+
+namespace ramiel {
+
+
+    //////////////////////////////// REVERSE TYPE LIST ////////////////////////////////
+
+    template<typename T, typename... Ts>
+    struct ReverseTs;
+
+    template<typename... Ts, typename... Us>
+    constexpr ReverseTs<Ts..., Us...> cat(ReverseTs<Ts...>, ReverseTs<Us...>);
+
+    template<typename T>
+    struct ReverseTs<T> {
+        using Type = ReverseTs<T>;
+    };
+
+    template<typename T, typename... Ts>
+    struct ReverseTs : private ReverseTs<Ts...> {
+        using Type = decltype(cat(
+            typename ReverseTs<Ts...>::Type{},
+            ReverseTs<T>{}
+        ));
+    };
+
+
+    //////////////////////////////// TUPLE ////////////////////////////////
+
+    template<typename T, typename... Ts>
+    struct TupleImpl;
+
+    template<typename... Ts>
+    TupleImpl<Ts...> tupleFromReverseTs(ReverseTs<Ts...>);
+
+    template<typename T>
+    struct TupleImpl<T> {
+        T val;
+
+        template<size_t N>
+        T& get() {
+            static_assert(N == 0, "tuple index out of bounds");
+            return val;
+        }
+
+        template<size_t N>
+        const T& get() const {
+            static_assert(N == 0, "tuple index out of bounds");
+            return val;
+        }
+    };
+
+    template<typename T, typename... Ts>
+    struct TupleImpl : private TupleImpl<Ts...> {
+        T val;
+        
+        template<size_t N>
+        auto& get() {
+            if constexpr (N == 0) return val;
+            else return TupleImpl<Ts...>::template get<N - 1>();
+        }
+        
+        template<size_t N>
+        const auto& get() const {
+            if constexpr (N == 0) return val;
+            else return TupleImpl<Ts...>::template get<N - 1>();
+        }
+    };
+
+
+    template<typename... Ts>
+    struct Tuple {
+        static constexpr size_t size = sizeof...(Ts);
+
+        using Reversed_ts = typename ReverseTs<Ts...>::Type;
+        using TupleImpl_t = decltype(tupleFromReverseTs(Reversed_ts{}));
+        TupleImpl_t tuple;
+
+        template<size_t N>
+        auto& get() {
+            static_assert(N < size, "tuple index out of range");
+            return tuple.template get<size - N - 1>();
+        }
+
+        template<size_t N>
+        const auto& get() const {
+            static_assert(N < size, "tuple index out of range");
+            return tuple.template get<size - N - 1>();
+        }
+    };
+
+
+    template<size_t... Ns, typename... Ts>
+    Tuple<Ts...> makeTupleImpl(std::index_sequence<Ns...>, const Ts&... args) {
+        Tuple<Ts...> tuple;
+        ((tuple.template get<Ns>() = args), ...);
+        return tuple;
+    }
+
+    template<typename... Ts>
+    Tuple<Ts...> makeTuple(const Ts&... args) {
+        return makeTupleImpl(std::make_index_sequence<sizeof...(Ts)>{}, args...);
+    }
+
+
+    //////////////////////////////// TUPLE ARITHMETIC ////////////////////////////////
+
+    template<size_t... Ns, typename... Ts>
+    Tuple<Ts...> addTupleImpl(std::index_sequence<Ns...>, const Tuple<Ts...>& l, const Tuple<Ts...>& r) {
+        Tuple<Ts...> res;
+        ((res.template get<Ns>() = l.template get<Ns>() + r.template get<Ns>()), ...);
+        return res;
+    }
+
+    template<size_t... Ns, typename... Ts>
+    Tuple<Ts...> subtractTupleImpl(std::index_sequence<Ns...>, const Tuple<Ts...>& l, const Tuple<Ts...>& r) {
+        Tuple<Ts...> res;
+        ((res.template get<Ns>() = l.template get<Ns>() - r.template get<Ns>()), ...);
+        return res;
+    }
+
+    template<typename U, size_t... Ns, typename... Ts>
+    Tuple<Ts...> scaleTupleImpl(std::index_sequence<Ns...>, const Tuple<Ts...>& l, const U& r) {
+        Tuple<Ts...> res;
+        ((res.template get<Ns>() = l.template get<Ns>() * r), ...);
+        return res;
+    }
+
+
+    template<typename... Ts>
+    Tuple<Ts...> operator+(const Tuple<Ts...>& l, const Tuple<Ts...>& r) {
+        return addTupleImpl(std::make_index_sequence<sizeof...(Ts)>{}, l, r);
+    }
+
+    template<typename... Ts>
+    Tuple<Ts...> operator-(const Tuple<Ts...>& l, const Tuple<Ts...>& r) {
+        return subtractTupleImpl(std::make_index_sequence<sizeof...(Ts)>{}, l, r);
+    }
+
+    template<typename U, typename... Ts>
+    Tuple<Ts...> operator*(const Tuple<Ts...>& l, const U& r) {
+        return scaleTupleImpl(std::make_index_sequence<sizeof...(Ts)>{}, l, r);
+    }
+
+    template<typename U, typename... Ts>
+    Tuple<Ts...> operator/(const Tuple<Ts...>& l, const U& r) {
+        return scaleTupleImpl(std::make_index_sequence<sizeof...(Ts)>{}, l, (U)1 / r);
+    }
+
+
+    //////////////////////////////// REFLECTION ////////////////////////////////
+
+    // my version of the great c++ type loophole!
+    // read more about it here:
+    // blog: https://alexpolt.github.io/type-loophole.html
+    // github: https://github.com/alexpolt/luple/
+
+
+    template<class T, int N>
+    struct FieldIndex {
+        friend auto getFieldType(FieldIndex<T, N>);
+    };
+
+    template<class T, typename U, int N>
+    struct GetFieldType_t {
+        friend auto getFieldType(FieldIndex<T, N>) { return U{}; };
+    };
+
+    template<class T, size_t N>
+    struct TypeDetector {
+        template<typename U, size_t = sizeof(GetFieldType_t<T, U, N>)>
+        operator U();
+    };
+
+    template<class T, size_t... Ns>
+    constexpr size_t getFieldCount(...) {
+        return sizeof...(Ns) - 1;
+    }
+
+    template<class T, size_t... Ns>
+    constexpr decltype(T{ TypeDetector<T, Ns>{}... }, 0) getFieldCount(size_t) {
+        static_assert(
+            std::is_aggregate<T>::value,
+            "cant create tuple from non-aggregate type"
+        );
+        return getFieldCount<T, Ns..., sizeof...(Ns)>(0);
+    }
+
+    template<class T, size_t... Ns>
+    constexpr Tuple<decltype(getFieldType(FieldIndex<T, Ns>{}))...>
+    asTupleImpl(std::index_sequence<Ns...>);
+
+    template<class T>
+    using AsTuple = decltype(asTupleImpl<T>(
+        std::make_index_sequence<getFieldCount<T>(0)>{}
+    ));
+    
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable("${PROJECT_NAME}_test"
     file/objloader.test.cpp 
     data/texture.test.cpp 
     math/transform.test.cpp 
+    data/tuple.test.cpp 
     math/vec.test.cpp 
     data/voidbuffer.test.cpp 
 )

--- a/tests/data/tuple.test.cpp
+++ b/tests/data/tuple.test.cpp
@@ -1,0 +1,80 @@
+#include <catch2/catch2.hpp>
+#include <ramiel/data.h>
+using namespace ramiel;
+
+
+struct TestStruct {
+    int m1;
+    double m2;
+    char m3;
+};
+
+using TestTuple = AsTuple<TestStruct>;
+
+
+TEST_CASE("tuple get", "[tuple]") {
+    TestTuple tuple;
+    tuple.get<0>() = 5;
+    tuple.get<1>() = 2.3;
+    tuple.get<2>() = 127;
+    
+    const TestTuple& ctuple = tuple;
+    REQUIRE(ctuple.get<0>() == 5);
+    REQUIRE(ctuple.get<1>() == 2.3);
+    REQUIRE(ctuple.get<2>() == 127);
+}
+
+
+TEST_CASE("tuple addition", "[tuple]") {
+    TestTuple l = makeTuple(5, 2.3, (char)127);
+    TestTuple r = makeTuple(1, 0.7, (char)1);
+
+    TestTuple res = l + r;
+    REQUIRE(res.get<0>() == 6);
+    REQUIRE(std::abs(res.get<1>() - 3.0) < 0.0001);
+    REQUIRE(res.get<2>() == -128);
+}
+
+
+TEST_CASE("tuple subtraction", "[tuple]") {
+    TestTuple l = makeTuple(5, 2.3, (char)127);
+    TestTuple r = makeTuple(1, 0.7, (char)1);
+
+    TestTuple res = l - r;
+    REQUIRE(res.get<0>() == 4);
+    REQUIRE(std::abs(res.get<1>() - 1.6) < 0.0001);
+    REQUIRE(res.get<2>() == 126);
+}
+
+
+TEST_CASE("tuple multiplication", "[tuple]") {
+    TestTuple l = makeTuple(5, 2.3, (char)127);
+    constexpr float r = 2.0f;
+
+    TestTuple res = l * r;
+    REQUIRE(res.get<0>() == 10);
+    REQUIRE(std::abs(res.get<1>() - 4.6) < 0.0001);
+    REQUIRE(res.get<2>() == -2);
+}
+
+
+TEST_CASE("tuple division", "[tuple]") {
+    TestTuple l = makeTuple(5, 2.3, (char)127);
+    constexpr float r = 2.0f;
+
+    TestTuple res = l / r;
+    REQUIRE(res.get<0>() == 2);
+    REQUIRE(std::abs(res.get<1>() - 1.15) < 0.0001);
+    REQUIRE(res.get<2>() == 63);
+
+}
+
+
+TEST_CASE("struct to tuple", "[tuple]") {
+    TestStruct s = { 5, 2.3, 'p' };
+    TestTuple& t = reinterpret_cast<TestTuple&>(s);
+
+    REQUIRE(t.get<0>() == 5);
+    REQUIRE(t.get<1>() == 2.3);
+    REQUIRE(t.get<2>() == 'p');
+}


### PR DESCRIPTION
added a tuple class. primary purpose is to reinterpret_cast from a user-defined vertex type. this will be used for interpolating vertex attributes during clipping and rasterization.

we are also using the c++ type loophole to automate the conversion from struct to tuple.
read more about it here:
- blog: https://alexpolt.github.io/type-loophole.html
- github: https://github.com/alexpolt/luple/