### PR TITLE
Geom clipping

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME} STATIC
     file/objloader.cpp 
     ramiel.cpp 
     data/texture.cpp 
+    graphics/triangle.cpp 
     data/voidbuffer.cpp 
 )
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/deps)

--- a/src/data/tuple.h
+++ b/src/data/tuple.h
@@ -156,10 +156,13 @@ namespace ramiel {
     // blog: https://alexpolt.github.io/type-loophole.html
     // github: https://github.com/alexpolt/luple/
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-template-friend"
     template<class T, int N>
     struct FieldIndex {
         friend auto getFieldType(FieldIndex<T, N>);
     };
+#pragma GCC diagnostic pop
 
     template<class T, typename U, int N>
     struct GetFieldType_t {

--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -6,8 +6,8 @@ using namespace ramiel;
 namespace {
 
     Vec2u res = Vec2u();
-    Vec2f halfRes = Vec2f();
     size_t bufferSize = 0;
+    float aspectRatio = 0.0f;
     
     std::vector<Vec3f> color;
     std::vector<float> depth;
@@ -21,10 +21,31 @@ namespace {
     float z1 = 1000.0f;
 
     Mat4x4f cameraTransform = id<float, 4>();
+    Mat4x4f projectionTransform = id<float, 4>();
+    Mat4x4f screenTransform = id<float, 4>();
 
 
     void calcCameraTransform() {
         cameraTransform = matmat(translate(-pos), rotate(rot));
+    }
+
+    void calcProjectionTransform() {
+        const float f = focalLen;
+        const float a = aspectRatio;
+        const float z = z1 / (z1 - z0);
+        projectionTransform = {
+            Vec4f{ f,    0,    0,    0    },
+            Vec4f{ 0,  a * f,  0,    0    },
+            Vec4f{ 0,    0,    z, -z0 * z },
+            Vec4f{ 0,    0,    1,    0    }
+        };
+    }
+
+    void calcScreenTransform() {
+        screenTransform = matmat(
+            translate(Vec3f{ 1.0f, 1.0f, 0.0f }),
+            scale(Vec3f{ res[X] / 2.0f, res[Y] / 2.0f, 1.0f })
+        );
     }
     
 }
@@ -37,15 +58,20 @@ namespace ramiel {
 
     void setRes(Vec2u newSize) {
         res = newSize;
-        halfRes = res / 2.0f;
         bufferSize = res[X] * res[Y];
-        focalLen = halfRes[X] / std::tan(fov / 2.0f);
+        aspectRatio = (float)res[X] / (float)res[Y];
         color = std::vector<Vec3f>(bufferSize);
         depth = std::vector<float>(bufferSize);
+        calcProjectionTransform();
+        calcScreenTransform();
     }
 
     size_t getBufferSize() {
         return bufferSize;
+    }
+
+    float getAspectRatio() {
+        return aspectRatio;
     }
 
 
@@ -104,23 +130,27 @@ namespace ramiel {
     void setFov(float deg) {
         assert(deg >= 1e-6 && deg <= 180.0f && "invalid fov");
         fov = deg * 0.01745f;
-        focalLen = halfRes[X] / std::tan(fov / 2.0f);
+        focalLen = 1.0f / std::tan(fov / 2.0f);
+        calcProjectionTransform();
     }
 
     void setFocalLen(float focalLen) {
         assert(focalLen >= 1e-6 && "invalid focal length");
         ::focalLen = std::max(0.0f, focalLen);
-        ::fov = 2.0f * std::atan(halfRes[X] / ::focalLen);
+        ::fov = 2.0f * std::atan(1.0f / ::focalLen);
+        calcProjectionTransform();
     }
 
     void setZ0(float z0) {
         assert(z0 >= 1e-6 && z0 <= ::z1 && "invalid z0");
         ::z0 = z0;
+        calcProjectionTransform();
     }
 
     void setZ1(float z1) {
         assert(z1 >= ::z0 && "invalid z1");
         ::z1 = z1;
+        calcProjectionTransform();
     }
 
 
@@ -128,14 +158,16 @@ namespace ramiel {
         return matvec(cameraTransform, in);
     }
 
+    Vec4f getProjectionCoord(const Vec4f& in) {
+        return matvec(projectionTransform, in);
+    }
+
+    Vec4f getNormalizedCoord(const Vec4f& in) {
+        return in / in[W];
+    }
+
     Vec4f getScreenCoord(const Vec4f& in) {
-        if (in[Z] == 0.0f) return Vec4f();
-        Vec4f out = Vec4f();
-        out[X] = std::floor(in[X] * focalLen / in[Z] + halfRes[X]);
-        out[Y] = std::floor(in[Y] * focalLen / in[Z] + halfRes[Y]);
-        out[Z] = in[Z];
-        out[W] = in[W];
-        return out;
+        return matvec(screenTransform, in);
     }
 
 }

--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -1,7 +1,16 @@
 #include <cassert>
 #include <cmath>
+
 #include "camera.h"
+#include "triangle.h"
 using namespace ramiel;
+
+namespace ramiel {
+
+    // definition in triangle.cpp ;)
+    void setHomogeneousCameraDepth(float z);
+
+}
 
 namespace {
 
@@ -39,6 +48,7 @@ namespace {
             Vec4f{ 0,    0,    z, -z0 * z },
             Vec4f{ 0,    0,    1,    0    }
         };
+        setHomogeneousCameraDepth(-z0 * z);
     }
 
     void calcScreenTransform() {

--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -8,7 +8,7 @@ using namespace ramiel;
 namespace ramiel {
 
     // definition in triangle.cpp ;)
-    void setHomogeneousCameraDepth(float z);
+    void updateViewFrustum();
 
 }
 
@@ -48,7 +48,7 @@ namespace {
             Vec4f{ 0,    0,    z, -z0 * z },
             Vec4f{ 0,    0,    1,    0    }
         };
-        setHomogeneousCameraDepth(-z0 * z);
+        updateViewFrustum();
     }
 
     void calcScreenTransform() {

--- a/src/graphics/camera.h
+++ b/src/graphics/camera.h
@@ -8,6 +8,7 @@ namespace ramiel {
     const Vec2u& getRes();
     void setRes(Vec2u size);
     size_t getBufferSize();
+    float getAspectRatio();
 
     typedef std::vector<Vec3f>::iterator ColorIt;
     typedef std::vector<float>::iterator DepthIt;
@@ -32,6 +33,8 @@ namespace ramiel {
     void setZ1(float z1);
 
     Vec4f getCameraCoord(const Vec4f& in);
+    Vec4f getProjectionCoord(const Vec4f& in);
+    Vec4f getNormalizedCoord(const Vec4f& in);
     Vec4f getScreenCoord(const Vec4f& in);
 
 }

--- a/src/graphics/entity.h
+++ b/src/graphics/entity.h
@@ -36,21 +36,18 @@ namespace ramiel {
             std::vector<typename VertexShader::Vertex_Out> v_out(numVertex);
             for (size_t i = 0; i < numVertex; ++i) {
                 v_out[i] = vertexShader(v_in[i]);
-                v_out[i].pos = getCameraCoord(v_out[i].pos);
+                v_out[i].pos = getProjectionCoord(getCameraCoord(v_out[i].pos));
             }
 
             const std::vector<Vec3u>& triangles = mesh.getTriangles();
             Triangle<typename VertexShader::Vertex_Out, PixelShader> tri(pixelShader);
             for (auto& t : triangles) {
-                // backface culling
-                if (dot(
-                    cross(
-                        v_out[t[1]].pos - v_out[t[0]].pos,
-                        v_out[t[2]].pos - v_out[t[0]].pos
-                    ),  v_out[t[0]].pos
-                ) >= 0.0f) continue;
+                if (!isFrontFacing(
+                    v_out[t[0]].pos,
+                    v_out[t[1]].pos,
+                    v_out[t[2]].pos
+                )) continue;
                 
-                // assemble and draw triangle
                 tri.draw(v_out[t[0]], v_out[t[1]], v_out[t[2]]);
             }
         }

--- a/src/graphics/entity.h
+++ b/src/graphics/entity.h
@@ -7,7 +7,7 @@ namespace ramiel {
 
     class EntityBase {
     public:
-        virtual void run() const = 0;
+        virtual void run() = 0;
     };
 
 
@@ -28,7 +28,7 @@ namespace ramiel {
         {}
 
 
-        virtual void run() const override {
+        virtual void run() override {
             // run vertex shader
             const std::vector<Vertex>& v_in = mesh.getVertices();
             const size_t numVertex = v_in.size();
@@ -40,7 +40,6 @@ namespace ramiel {
             }
 
             const std::vector<Vec3u>& triangles = mesh.getTriangles();
-            Triangle<typename VertexShader::Vertex_Out, PixelShader> tri(pixelShader);
             for (auto& t : triangles) {
                 if (!isFrontFacing(
                     v_out[t[0]].pos,
@@ -48,7 +47,7 @@ namespace ramiel {
                     v_out[t[2]].pos
                 )) continue;
                 
-                tri.draw(v_out[t[0]], v_out[t[1]], v_out[t[2]]);
+                draw(pixelShader, v_out[t[0]], v_out[t[1]], v_out[t[2]]);
             }
         }
 

--- a/src/graphics/entity.h
+++ b/src/graphics/entity.h
@@ -36,17 +36,11 @@ namespace ramiel {
             std::vector<typename VertexShader::Vertex_Out> v_out(numVertex);
             for (size_t i = 0; i < numVertex; ++i) {
                 v_out[i] = vertexShader(v_in[i]);
-                v_out[i].pos = getProjectionCoord(getCameraCoord(v_out[i].pos));
+                v_out[i].pos = getCameraCoord(v_out[i].pos);
             }
 
             const std::vector<Vec3u>& triangles = mesh.getTriangles();
             for (auto& t : triangles) {
-                if (!isFrontFacing(
-                    v_out[t[0]].pos,
-                    v_out[t[1]].pos,
-                    v_out[t[2]].pos
-                )) continue;
-                
                 draw(pixelShader, v_out[t[0]], v_out[t[1]], v_out[t[2]]);
             }
         }

--- a/src/graphics/triangle.cpp
+++ b/src/graphics/triangle.cpp
@@ -1,0 +1,13 @@
+#include "triangle.h"
+
+namespace ramiel {
+
+    bool isFrontFacing(const Vec4f& v1, const Vec4f& v2, const Vec4f& v3) {
+        return 0.0f > det(Mat3x3f{
+            Vec3f{ v1[X], v1[Y], v1[Z] },
+            Vec3f{ v2[X], v2[Y], v2[Z] },
+            Vec3f{ v3[X], v3[Y], v3[Z] }
+        });
+    }
+
+}

--- a/src/graphics/triangle.cpp
+++ b/src/graphics/triangle.cpp
@@ -1,6 +1,60 @@
 #include "triangle.h"
+using namespace ramiel;
+
+namespace {
+
+    Vec4f intersect(
+        const Vec4f& v0,
+        const Vec4f& v1
+    ) {
+        float c = -v1[Z] / (v0[Z] - v1[Z]);
+        return v1 + (v0 - v1) * c;
+    }
+
+    void clip1v(
+        const Vec4f& v0,
+        const Vec4f& v1,
+        const Vec4f& v2,
+        TriList& out
+    ) {
+        Vec4f vc0 = intersect(v0, v1);
+        Vec4f vc2 = intersect(v2, v1);
+        out.emplace_front(Tri{ v0, vc0, vc2 });
+        out.emplace_front(Tri{ vc2, v2, v0 });
+    }
+
+    void clip2v(
+        const Vec4f& v0,
+        const Vec4f& v1,
+        const Vec4f& v2,
+        TriList& out
+    ) {
+        Vec4f vc0 = intersect(v0, v1);
+        Vec4f vc2 = intersect(v2, v1);
+        out.emplace_front(Tri{ vc0, v1, vc2 });
+    }
+
+}
 
 namespace ramiel {
+
+    TriInterpolate3d::TriInterpolate3d(const Vec4f& v0, const Vec4f& v1, const Vec4f& v2) {
+        this->v1 = reinterpret_cast<const Vec3f&>(v1);
+        x = reinterpret_cast<const Vec3f&>(v0) - reinterpret_cast<const Vec3f&>(v1);
+        y = reinterpret_cast<const Vec3f&>(v2) - reinterpret_cast<const Vec3f&>(v1);
+        z = normalize(cross(x, y));
+        a = 1.0f / det(Mat3x3f{ x, y, z });
+    }
+
+    Vec3f TriInterpolate3d::operator()(const Vec4f& p) const {
+        Vec3f vp = reinterpret_cast<const Vec3f&>(p) - v1;
+        Vec3f weights;
+        weights[0] = det(Mat3x3f{ vp, y, z }) * a;
+        weights[2] = det(Mat3x3f{ x, vp, z }) * a;
+        weights[1] = 1.0f - (weights[0] + weights[2]);
+        return weights;
+    }
+
 
     bool isFrontFacing(const Vec4f& v1, const Vec4f& v2, const Vec4f& v3) {
         return 0.0f > det(Mat3x3f{
@@ -8,6 +62,29 @@ namespace ramiel {
             Vec3f{ v2[X], v2[Y], v2[Z] },
             Vec3f{ v3[X], v3[Y], v3[Z] }
         });
+    }
+
+
+    bool clip(
+        const Vec4f& v0,
+        const Vec4f& v1,
+        const Vec4f& v2,
+        TriList& clippedTris
+    ) {
+        if (v0[Z] < 0.0f) {
+            if (v1[Z] < 0.0f) {
+                if (v2[Z] < 0.0f) return false;
+                else clip2v(v1, v2, v0, clippedTris);
+            }
+            else if (v2[Z] < 0.0f) clip2v(v0, v1, v2, clippedTris);
+            else clip1v(v2, v0, v1, clippedTris);
+        }
+        else if (v1[Z] < 0.0f) {
+            if (v2[Z] < 0.0f) clip2v(v2, v0, v1, clippedTris);
+            else clip1v(v0, v1, v2, clippedTris);
+        }
+        else if (v2[Z] < 0.0f) clip1v(v1, v2, v0, clippedTris);
+        return true;
     }
 
 }

--- a/src/graphics/triangle.h
+++ b/src/graphics/triangle.h
@@ -11,144 +11,134 @@ namespace ramiel {
     bool isFrontFacing(const Vec4f& v1, const Vec4f& v2, const Vec4f& v3);
 
 
-    template<typename Vertex, class PixelShader>
-    class Triangle {
-        using VtTuple = AsTuple<Vertex>;
-        VtTuple v[3];
-        PixelShader pixelShader;
+    template<class PixelShader, class Vertex>
+    void raster(PixelShader& ps, std::array<AsTuple<Vertex>, 3>& v) {
+        for (size_t i = 0; i < 3; ++i) {
+            v[i].POS = getScreenCoord(getNormalizedCoord(v[i].POS));
 
-        public:
-        Triangle(PixelShader pixelShader) : pixelShader(pixelShader) {}
+            // temp!! rasterization will be redone soon
+            v[i].POS[X] = std::floor(v[i].POS[X]);
+            v[i].POS[Y] = std::floor(v[i].POS[Y]);
+        }
 
+        ColorIt color = getColorBuffer();
+        DepthIt depth = getDepthBuffer();
+        
+        if (v[0].POS[Y] > v[1].POS[Y]) std::swap(v[0], v[1]);
+        if (v[0].POS[Y] > v[2].POS[Y]) std::swap(v[0], v[2]);
+        if (v[1].POS[Y] > v[2].POS[Y]) std::swap(v[1], v[2]);
 
-        private:
-        void raster() {
-            for (size_t i = 0; i < 3; ++i) {
-                v[i].POS = getScreenCoord(getNormalizedCoord(v[i].POS));
+        AsTuple<Vertex> dy1 = (v[2] - v[0]) / (v[2].POS[Y] - v[0].POS[Y]);
+        AsTuple<Vertex> dy2 = (v[1] - v[0]) / (v[1].POS[Y] - v[0].POS[Y]);
+        AsTuple<Vertex>* dy;
+        if (dy1.POS[X] > dy2.POS[X]) {
+            std::swap(dy1, dy2);
+            dy = &dy1;
+        }
+        else dy = &dy2;
 
-                // temp!! rasterization will be redone soon
-                v[i].POS[X] = std::floor(v[i].POS[X]);
-                v[i].POS[Y] = std::floor(v[i].POS[Y]);
-            }
+        int y = std::max<int>(0, v[0].POS[Y]);
+        int ymax = std::min<int>(v[1].POS[Y], getRes()[Y]);
+        AsTuple<Vertex> sc1 = v[0] + dy1 * (float)(y - v[0].POS[Y]);
+        AsTuple<Vertex> sc2 = v[0] + dy2 * (float)(y - v[0].POS[Y]);
+        
+        auto drawHalf = [&]() {
+            for (y; y < ymax; ++y) {
+                AsTuple<Vertex> dx = (sc2 - sc1) / (sc2.POS[X] - sc1.POS[X]);
 
-            ColorIt color = getColorBuffer();
-            DepthIt depth = getDepthBuffer();
-            
-            if (v[0].POS[Y] > v[1].POS[Y]) std::swap(v[0], v[1]);
-            if (v[0].POS[Y] > v[2].POS[Y]) std::swap(v[0], v[2]);
-            if (v[1].POS[Y] > v[2].POS[Y]) std::swap(v[1], v[2]);
+                int x = std::max<int>(0, sc1.POS[X]);
+                int xmax = std::min<int>(sc2.POS[X], getRes()[X]);
+                AsTuple<Vertex> p = sc1 + dx * (float)(x - sc1.POS[X]);
+                size_t i = getRes()[X] * y + x;
 
-            VtTuple dy1 = (v[2] - v[0]) / (v[2].POS[Y] - v[0].POS[Y]);
-            VtTuple dy2 = (v[1] - v[0]) / (v[1].POS[Y] - v[0].POS[Y]);
-            VtTuple* dy;
-            if (dy1.POS[X] > dy2.POS[X]) {
-                std::swap(dy1, dy2);
-                dy = &dy1;
-            }
-            else dy = &dy2;
-
-            int y = std::max<int>(0, v[0].POS[Y]);
-            int ymax = std::min<int>(v[1].POS[Y], getRes()[Y]);
-            VtTuple sc1 = v[0] + dy1 * (float)(y - v[0].POS[Y]);
-            VtTuple sc2 = v[0] + dy2 * (float)(y - v[0].POS[Y]);
-            
-            auto drawHalf = [&]() {
-                for (y; y < ymax; ++y) {
-                    VtTuple dx = (sc2 - sc1) / (sc2.POS[X] - sc1.POS[X]);
-
-                    int x = std::max<int>(0, sc1.POS[X]);
-                    int xmax = std::min<int>(sc2.POS[X], getRes()[X]);
-                    VtTuple p = sc1 + dx * (float)(x - sc1.POS[X]);
-                    size_t i = getRes()[X] * y + x;
-
-                    for (x; x < xmax; ++x) {
-                        if (p.POS[Z] < depth[i]) {
-                            depth[i] = p.POS[Z];
-                            color[i] = pixelShader.draw(reinterpret_cast<const Vertex&>(p));
-                        }
-                        ++i;
-                        p = p + dx;
+                for (x; x < xmax; ++x) {
+                    if (p.POS[Z] < depth[i]) {
+                        depth[i] = p.POS[Z];
+                        color[i] = ps.draw(reinterpret_cast<const Vertex&>(p));
                     }
-                    sc1 = sc1 + dy1;
-                    sc2 = sc2 + dy2;
+                    ++i;
+                    p = p + dx;
                 }
-            };
-            
-            drawHalf();
-
-            ymax = std::min<int>(v[2].POS[Y], getRes()[Y]);
-            *dy = (v[2] - v[1]) / (v[2].POS[Y] - v[1].POS[Y]);
-            sc1 = v[2] - dy1 * (float)(v[2].POS[Y] - y);
-            sc2 = v[2] - dy2 * (float)(v[2].POS[Y] - y);
-            
-            drawHalf();
-        }
-
-
-        private:
-        void clip1(VtTuple& v0, VtTuple& v1, VtTuple& v2) {
-            // ratio of line clipped
-            float c1 = -v1.POS[Z] / (v0.POS[Z] - v1.POS[Z]);
-            float c2 = -v1.POS[Z] / (v2.POS[Z] - v1.POS[Z]);
-
-            // new tri formed from quad
-            Triangle newtri = Triangle(pixelShader);
-
-            // clip and raster new tri
-            newtri.v[0] = v1 + (v0 - v1) * c1;
-            newtri.v[1] = v1 + (v2 - v1) * c2;
-            newtri.v[2] = v2;
-            v1 = newtri.v[0];
-
-            newtri.raster();
-        }
-
-
-        private:
-        void clip2(VtTuple& v0, VtTuple& v1, VtTuple& v2) {
-            // ratio of line clipped
-            float c1 = -v0.POS[Z] / (v1.POS[Z] - v0.POS[Z]);
-            float c2 = -v2.POS[Z] / (v1.POS[Z] - v2.POS[Z]);
-
-            // clip
-            v0 = v0 + (v1 - v0) * c1;
-            v2 = v2 + (v1 - v2) * c2;
-        }
-
-
-        private:
-        bool clip() {
-            if (v[0].POS[Z] < 0.0f) {
-                if (v[1].POS[Z] < 0.0f) {
-                    if (v[2].POS[Z] < 0.0f) return false;
-                    else clip2(v[1], v[2], v[0]);
-                }
-                else if (v[2].POS[Z] < 0.0f) clip2(v[0], v[1], v[2]);
-                else clip1(v[2], v[0], v[1]);
+                sc1 = sc1 + dy1;
+                sc2 = sc2 + dy2;
             }
-            else if (v[1].POS[Z] < 0.0f) {
-                if (v[2].POS[Z] < 0.0f) clip2(v[2], v[0], v[1]);
-                else clip1(v[0], v[1], v[2]);
+        };
+        
+        drawHalf();
+
+        ymax = std::min<int>(v[2].POS[Y], getRes()[Y]);
+        *dy = (v[2] - v[1]) / (v[2].POS[Y] - v[1].POS[Y]);
+        sc1 = v[2] - dy1 * (float)(v[2].POS[Y] - y);
+        sc2 = v[2] - dy2 * (float)(v[2].POS[Y] - y);
+        
+        drawHalf();
+    }
+
+
+    template<class PixelShader, class Vertex>
+    void clip1(PixelShader& ps, AsTuple<Vertex>& v0, AsTuple<Vertex>& v1, AsTuple<Vertex>& v2) {
+        // ratio of line clipped
+        float c1 = -v1.POS[Z] / (v0.POS[Z] - v1.POS[Z]);
+        float c2 = -v1.POS[Z] / (v2.POS[Z] - v1.POS[Z]);
+
+        // new tri formed from quad
+        std::array<AsTuple<Vertex>, 3> v = {
+            v1 + (v0 - v1) * c1,
+            v1 + (v2 - v1) * c2,
+            v2
+        };
+        raster<PixelShader, Vertex>(ps, v);
+
+        v1 = v[0];
+    }
+
+
+    template<class PixelShader, class Vertex>
+    void clip2(AsTuple<Vertex>& v0, AsTuple<Vertex>& v1, AsTuple<Vertex>& v2) {
+        // ratio of line clipped
+        float c1 = -v0.POS[Z] / (v1.POS[Z] - v0.POS[Z]);
+        float c2 = -v2.POS[Z] / (v1.POS[Z] - v2.POS[Z]);
+
+        // clip
+        v0 = v0 + (v1 - v0) * c1;
+        v2 = v2 + (v1 - v2) * c2;
+    }
+
+
+    template<class PixelShader, class Vertex>
+    bool clip(PixelShader& ps, std::array<AsTuple<Vertex>, 3>& v) {
+        if (v[0].POS[Z] < 0.0f) {
+            if (v[1].POS[Z] < 0.0f) {
+                if (v[2].POS[Z] < 0.0f) return false;
+                else clip2<PixelShader, Vertex>(v[1], v[2], v[0]);
             }
-            else if (v[2].POS[Z] < 0.0f) clip1(v[1], v[2], v[0]);
-            return true;
+            else if (v[2].POS[Z] < 0.0f) clip2<PixelShader, Vertex>(v[0], v[1], v[2]);
+            else clip1<PixelShader, Vertex>(ps, v[2], v[0], v[1]);
         }
-
-
-        public:
-        void draw(
-            const Vertex& v0,
-            const Vertex& v1,
-            const Vertex& v2
-        ) {
-            assertValidVertex<Vertex>();
-            v[0] = reinterpret_cast<const VtTuple&>(v0);
-            v[1] = reinterpret_cast<const VtTuple&>(v1);
-            v[2] = reinterpret_cast<const VtTuple&>(v2);
-            pixelShader.init(reinterpret_cast<Vertex*>(v));
-            if (clip()) raster();
+        else if (v[1].POS[Z] < 0.0f) {
+            if (v[2].POS[Z] < 0.0f) clip2<PixelShader, Vertex>(v[2], v[0], v[1]);
+            else clip1<PixelShader, Vertex>(ps, v[0], v[1], v[2]);
         }
+        else if (v[2].POS[Z] < 0.0f) clip1<PixelShader, Vertex>(ps, v[1], v[2], v[0]);
+        return true;
+    }
 
-    };
+
+    template<class PixelShader, class Vertex>
+    void draw(
+        PixelShader& ps,
+        const Vertex& v0,
+        const Vertex& v1,
+        const Vertex& v2
+    ) {
+        assertValidVertex<Vertex>();
+        std::array<AsTuple<Vertex>, 3> v = {
+            reinterpret_cast<const AsTuple<Vertex>&>(v0),
+            reinterpret_cast<const AsTuple<Vertex>&>(v1),
+            reinterpret_cast<const AsTuple<Vertex>&>(v2)
+        };
+        ps.init(reinterpret_cast<Vertex*>(&v));
+        if (clip<PixelShader, Vertex>(ps, v)) raster<PixelShader, Vertex>(ps, v);
+    }
 
 }

--- a/src/graphics/triangle.h
+++ b/src/graphics/triangle.h
@@ -23,7 +23,7 @@ namespace ramiel {
         float a;
     };
 
-    bool isFrontFacing(const Vec4f& v1, const Vec4f& v2, const Vec4f& v3);
+    bool isFrontFacing(const Vec4f& v0, const Vec4f& v1, const Vec4f& v2);
 
     using Tri = std::array<Vec4f, 3>;
     using TriList = std::forward_list<Tri>;

--- a/src/graphics/triangle.h
+++ b/src/graphics/triangle.h
@@ -25,6 +25,10 @@ namespace ramiel {
         void raster() {
             for (size_t i = 0; i < 3; ++i) {
                 v[i].POS = getScreenCoord(getNormalizedCoord(v[i].POS));
+
+                // temp!! rasterization will be redone soon
+                v[i].POS[X] = std::floor(v[i].POS[X]);
+                v[i].POS[Y] = std::floor(v[i].POS[Y]);
             }
 
             ColorIt color = getColorBuffer();

--- a/src/graphics/vertex.h
+++ b/src/graphics/vertex.h
@@ -3,6 +3,9 @@
 #include <type_traits>
 #include <ramiel/math.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+
 namespace ramiel {
 
     template<class T, typename = void>
@@ -29,3 +32,5 @@ namespace ramiel {
     }
 
 }
+
+#pragma GCC diagnostic pop

--- a/src/math/mat.h
+++ b/src/math/mat.h
@@ -77,6 +77,14 @@ namespace ramiel {
         return in[0][0] * in[1][1] - in[0][1] * in[1][0];
     }
 
+    template<typename T>
+    T det(const Vec<Vec<T, 3>, 3>& in) {
+        T a = in[1][1] * in[2][2] - in[1][2] * in[2][1];
+        T b = in[1][0] * in[2][2] - in[1][2] * in[2][0];
+        T c = in[1][0] * in[2][1] - in[1][1] * in[2][0];
+        return in[0][0] * a - in[0][1] * b + in[0][2] * c;
+    }
+
     template<typename T, size_t N>
     T det(const Vec<Vec<T, N>, N>& in) {
         static_assert(N < 10, "matrix too large");

--- a/src/math/vec.h
+++ b/src/math/vec.h
@@ -92,6 +92,19 @@ namespace ramiel {
     }
 
 
+    template<size_t M, typename T, size_t N>
+    const Vec<T, M>& sizeView(const Vec<T, N>& v) {
+        static_assert(M < N, "vector size view can only reduce size");
+        return reinterpret_cast<const Vec<T, M>&>(v);
+    }
+
+    template<size_t M, typename T, size_t N>
+    Vec<T, M>& sizeView(Vec<T, N>& v) {
+        static_assert(M < N, "vector size view can only reduce size");
+        return reinterpret_cast<Vec<T, M>&>(v);
+    }
+
+
     template<typename T, size_t N>
     T dot(const Vec<T, N>& v1, const Vec<T, N>& v2) {
         T d = (T)0;


### PR DESCRIPTION
added geometric clipping for all 6 view frustum boundaries. clipping is done using plane-line intersections. it works only with Vec4f camera coordinates, and so is no longer templated. cant remove raster clipping just yet, because the lack of proper rasterization rules means we sometimes still draw to out of bounds pixels